### PR TITLE
Set compat bounds for CImGui

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,3 +25,6 @@ Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[compat]
+CImGui = "~1.89"


### PR DESCRIPTION
Making the PR because there's a new release: https://github.com/Gnimuc/CImGui.jl/releases/tag/v1.89.0
And I see from the manifest that this is already 1.89 compatible :) You should be able to point it back to the registry now instead of my fork.